### PR TITLE
Tweaked the libtasn1/print_results.sh script to work with CVE-2014-3467

### DIFF
--- a/libtasn1/print-results.sh
+++ b/libtasn1/print-results.sh
@@ -6,9 +6,9 @@ print_single_result()
 {
     paste -d ',' \
     <( echo "$2" ) \
-    <( grep Elapsed $1*/*-coverage/info | cut -d ' ' -f2 ) \
-    <( grep Elapsed $1*/*-dfs/info | cut -d ' ' -f2 ) \
-    <( grep Elapsed $1*/*-random/info | cut -d ' ' -f2 )
+    <( grep Elapsed $1*/*-coverage$3/info | cut -d ' ' -f2 ) \
+    <( grep Elapsed $1*/*-dfs$3/info | cut -d ' ' -f2 ) \
+    <( grep Elapsed $1*/*-random$3/info | cut -d ' ' -f2 )
 }
 
 # Parameters: 1- directory, 2- label
@@ -17,9 +17,9 @@ print_multiple_result()
 {
     paste -d ',' \
 	  <( for num in `seq 10 10 50`; do echo "$2 $num"; done ) \
-	  <( grep Elapsed $1-*/*-coverage/info | cut -d ' ' -f2 ) \
-	  <( grep Elapsed $1-*/*-dfs/info | cut -d ' ' -f2 ) \
-	  <( grep Elapsed $1-*/*-random/info | cut -d ' ' -f2 )
+	  <( grep Elapsed $1-*/*-coverage$3/info | cut -d ' ' -f2 ) \
+	  <( grep Elapsed $1-*/*-dfs$3/info | cut -d ' ' -f2 ) \
+	  <( grep Elapsed $1-*/*-random$3/info | cut -d ' ' -f2 )
 }
 
 print_header()
@@ -29,19 +29,28 @@ print_header()
 
 print_results()
 {
+    if [ -n "$2" ]
+    then
+        SUBBENCH="-$2"
+    else
+        SUBBENCH=""
+    fi
+    echo "===== Running on '$1$SUBBENCH' =====" >&2
     cd $1
     print_header
-    print_single_result   "klee" "KLEE"
-    print_single_result   "cse-no-searcher" "STANDARD"
-    print_multiple_result "cse-split-searcher" "SPLIT-SEARCH"
-    print_multiple_result "cse-recovery-searcher-rp" "RECOVERY-SEARCH-RP"
-    print_multiple_result "cse-recovery-searcher-dfs" "RECOVERY-SEARCH-DFS"
+    print_single_result   "klee" "KLEE" $SUBBENCH
+    print_single_result   "cse-no-searcher" "STANDARD" $SUBBENCH
+    print_multiple_result "cse-split-searcher" "SPLIT-SEARCH" $SUBBENCH
+    print_multiple_result "cse-recovery-searcher-rp" "RECOVERY-SEARCH-RP" $SUBBENCH
+    print_multiple_result "cse-recovery-searcher-dfs" "RECOVERY-SEARCH-DFS" $SUBBENCH
     cd ..
 }
 
 
 ## MAIN
 print_results CVE-2012-1569 > CVE-2012-1569.csv
-print_results CVE-2014-3467 > CVE-2014-3467.csv
+print_results CVE-2014-3467 1 > CVE-2014-3467_1.csv
+print_results CVE-2014-3467 2 > CVE-2014-3467_2.csv
+print_results CVE-2014-3467 3 > CVE-2014-3467_3.csv
 print_results CVE-2015-2806 > CVE-2015-2806.csv
 print_results CVE-2015-3622 > CVE-2015-3622.csv


### PR DESCRIPTION
`print_results.sh` is broken on master for CVE-2014-3467, because there are three bugs in this CVE, and `CVE-2014-3467/Makefile` runs three times, once for each bug:

https://github.com/andreamattavelli/chopper-experiments/blob/adbd84638d483ffe04fb0d3246828bf2f62130d8/libtasn1/CVE-2014-3467/Makefile#L34-L60

With this patch, `print_results.sh` will output three CSV files for this CVE:

```console
❯ tail CVE-2014-3467_*
==> CVE-2014-3467_1.csv <==
RECOVERY-SEARCH-RP 10,00:09:14,00:00:43,
RECOVERY-SEARCH-RP 20,,00:12:15,
RECOVERY-SEARCH-RP 30,,00:13:23,
RECOVERY-SEARCH-RP 40,,00:13:18,
RECOVERY-SEARCH-RP 50,,00:13:16,
RECOVERY-SEARCH-DFS 10,00:04:26,00:00:48,
RECOVERY-SEARCH-DFS 20,,00:09:55,
RECOVERY-SEARCH-DFS 30,,00:13:07,
RECOVERY-SEARCH-DFS 40,,00:12:59,
RECOVERY-SEARCH-DFS 50,,00:12:57,

==> CVE-2014-3467_2.csv <==
RECOVERY-SEARCH-RP 10,00:00:04,00:09:10,00:00:08
RECOVERY-SEARCH-RP 20,00:00:05,00:13:59,00:00:04
RECOVERY-SEARCH-RP 30,00:00:10,00:13:53,00:00:04
RECOVERY-SEARCH-RP 40,00:00:12,,00:00:04
RECOVERY-SEARCH-RP 50,00:00:05,,00:00:05
RECOVERY-SEARCH-DFS 10,00:00:24,,00:00:06
RECOVERY-SEARCH-DFS 20,00:00:06,,00:00:06
RECOVERY-SEARCH-DFS 30,00:16:10,,00:00:06
RECOVERY-SEARCH-DFS 40,00:00:05,,00:00:06
RECOVERY-SEARCH-DFS 50,00:00:07,,00:00:07

==> CVE-2014-3467_3.csv <==
RECOVERY-SEARCH-RP 10,00:02:44,00:04:59,00:03:20
RECOVERY-SEARCH-RP 20,00:02:27,,00:16:29
RECOVERY-SEARCH-RP 30,,,
RECOVERY-SEARCH-RP 40,,,
RECOVERY-SEARCH-RP 50,,,
RECOVERY-SEARCH-DFS 10,00:06:15,,
RECOVERY-SEARCH-DFS 20,,,
RECOVERY-SEARCH-DFS 30,,,
RECOVERY-SEARCH-DFS 40,,,
RECOVERY-SEARCH-DFS 50,,,
```