### PR TITLE
Add missing --error-location on CVE-2014-3467 KLEE runs

### DIFF
--- a/libtasn1/CVE-2014-3467/Makefile
+++ b/libtasn1/CVE-2014-3467/Makefile
@@ -62,7 +62,7 @@ run-klee-random-3: $(TARGET)
 run-klee-dfs-1: $(TARGET)
 	echo "** Running KLEE with dfs search"
 	-$(KLEE) \
-	--exit-on-error-type=Ptr \
+	--exit-on-error-type=Ptr --error-location=decoding.c:152 \
 	--libc=uclibc --posix-runtime \
 	--search=dfs \
 	--output-dir=klee-run-dfs-1 \
@@ -71,7 +71,7 @@ run-klee-dfs-1: $(TARGET)
 run-klee-dfs-2: $(TARGET)
 	echo "** Running KLEE with dfs search"
 	-$(KLEE) \
-	--exit-on-error-type=Ptr \
+	--exit-on-error-type=Ptr --error-location=decoding.c:709 \
 	--libc=uclibc --posix-runtime \
 	--search=dfs \
 	--output-dir=klee-run-dfs-2 \
@@ -80,7 +80,7 @@ run-klee-dfs-2: $(TARGET)
 run-klee-dfs-3: $(TARGET)
 	echo "** Running KLEE with dfs search"
 	-$(KLEE) \
-	--exit-on-error-type=Ptr \
+	--exit-on-error-type=Ptr --error-location=decoding.c:1131 \
 	--libc=uclibc --posix-runtime \
 	--search=dfs \
 	--output-dir=klee-run-dfs-3 \
@@ -90,7 +90,7 @@ run-klee-dfs-3: $(TARGET)
 run-klee-coverage-1: $(TARGET)
 	echo "** Running KLEE with coverage search"
 	-$(KLEE) \
-	--exit-on-error-type=Ptr \
+	--exit-on-error-type=Ptr --error-location=decoding.c:152 \
 	--libc=uclibc --posix-runtime \
 	--search=nurs:covnew \
 	--output-dir=klee-run-coverage-1 \
@@ -99,7 +99,7 @@ run-klee-coverage-1: $(TARGET)
 run-klee-coverage-2: $(TARGET)
 	echo "** Running KLEE with coverage search"
 	-$(KLEE) \
-	--exit-on-error-type=Ptr \
+	--exit-on-error-type=Ptr --error-location=decoding.c:709 \
 	--libc=uclibc --posix-runtime \
 	--search=nurs:covnew \
 	--output-dir=klee-run-coverage-2 \
@@ -108,7 +108,7 @@ run-klee-coverage-2: $(TARGET)
 run-klee-coverage-3: $(TARGET)
 	echo "** Running KLEE with coverage search"
 	-$(KLEE) \
-	--exit-on-error-type=Ptr \
+	--exit-on-error-type=Ptr --error-location=decoding.c:1131 \
 	--libc=uclibc --posix-runtime \
 	--search=nurs:covnew \
 	--output-dir=klee-run-coverage-3 \


### PR DESCRIPTION
This fixes an error in the Makefile that causes much better run results for CVE-2014-3467/KLEE non-`random-state` runs